### PR TITLE
replaced meta tags content

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,11 +1,9 @@
 title: D-EITI
 
 description: >
-  auf rohstofftransparenz.de, dem Informationsportal der deutschen Initiative für
-  Transparenz im rohstoffgewinnenden Sektor (D-EITI).
-  Eine verständliche Darstellung von Themen und mehr Transparenz im rohstoffgewinnenden
-  Sektor ist das gemeinsame Ziel der D-EITI-Initiative und ihren Mitgliedern aus
-  Regierung, Wirtschaft und Zivilgesellschaft.
+  Rohstofftransparenz.de ist das Informationsportal der deutschen Initiative
+  für Transparenz im rohstoffgewinnenden Sektor (D-EITI). D-EITI ist eine Initiative
+  mit Mitgliedern aus Regierung, Wirtschaft und Zivilgesellschaft.
 
 # permanent url, for use in meta references
 url:  http://www.rohstofftransparenz.de

--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,14 @@
 title: D-EITI
 
 description: >
-    USEITI is part of an international effort to promote open and accountable
-    management of natural resources. This site provides data about how the U.S.
-    manages extractive industries.
+  auf rohstofftransparenz.de, dem Informationsportal der deutschen Initiative für
+  Transparenz im rohstoffgewinnenden Sektor (D-EITI).
+  Eine verständliche Darstellung von Themen und mehr Transparenz im rohstoffgewinnenden
+  Sektor ist das gemeinsame Ziel der D-EITI-Initiative und ihren Mitgliedern aus
+  Regierung, Wirtschaft und Zivilgesellschaft.
 
 # permanent url, for use in meta references
-url: https://useiti.doi.gov
+url:  http://www.rohstofftransparenz.de
 
 # app version number
 version: v1.3.3

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,9 +35,9 @@
     <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.url }}">
 
     <!-- img -->
-    <meta property="og:img" content="{{ site.url }}/img/explore-home-revenue.png">
+    <meta property="og:img" content="{{ site.url }}/img/carousel/oil.png">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:image" content="{{ site.url }}/img/explore-home-revenue.png">
+    <meta name="twitter:image" content="{{ site.url }}/img/carousel/oil.png">
 
     <!-- description -->
     <meta property="og:description" content="{{ site.description }}">


### PR DESCRIPTION
https://pfeffermind.atlassian.net/browse/GRM-74
- i replaced this "share image":
![unfurl_image](https://cloud.githubusercontent.com/assets/11651398/22648732/53354ee2-ec4e-11e6-81ac-586df6b411e6.png)
with this one:
![oil](https://cloud.githubusercontent.com/assets/11651398/22648528/78392444-ec4d-11e6-85ba-34c8d26b620a.png)
which is the best that i found within our project, i guess we'll have a better one later. At least it's not the USA map.

- I replaced this description: 
USEITI is part of an international effort to promote open and accountable management of natural resources. This site provides data about how the U.S. manages extractive industries.

with this one:
  auf rohstofftransparenz.de, dem Informationsportal der deutschen Initiative für
  Transparenz im rohstoffgewinnenden Sektor (D-EITI).
  Eine verständliche Darstellung von Themen und mehr Transparenz im rohstoffgewinnenden
  Sektor ist das gemeinsame Ziel der D-EITI-Initiative und ihren Mitgliedern aus
  Regierung, Wirtschaft und Zivilgesellschaft.


**Edit**
new description:
"Rohstofftransparenz.de ist das Informationsportal der deutschen Initiative für Transparenz im rohstoffgewinnenden Sektor (D-EITI). D-EITI ist eine Initiative mit Mitgliedern aus Regierung, Wirtschaft und Zivilgesellschaft."