### PR TITLE
added _sticky.scss

### DIFF
--- a/_sass/components/_all.scss
+++ b/_sass/components/_all.scss
@@ -17,3 +17,4 @@
 @import 'breadcrumbs';
 @import 'flowchart';
 @import 'menu-tiles';
+@import 'sticky';

--- a/_sass/components/_sticky.scss
+++ b/_sass/components/_sticky.scss
@@ -1,0 +1,22 @@
+.sticky {
+  background: $white;
+  padding-top: $standard-padding-lite;
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: $z-roof;
+}
+
+.sticky::before,
+.sticky::after {
+  content: '';
+  display: table;
+}
+
+.sticky-float {
+  float: left;
+}
+
+.sticky-sibling {
+  margin-right: 0;
+}


### PR DESCRIPTION
https://pfeffermind.atlassian.net/browse/GRM-82

18f ("upstream") has been using some CSS3 instead of Javascript to stick the right sidebar. That's why USEITI's sidebar wasn't affected by the last Google Chrome update, which apparently broke some JS.