### PR TITLE
fixed sidemenu issue on google chrome version 56 in pages with charts

### DIFF
--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -129,7 +129,6 @@
           if (this.diffBottom >= 0){
             if (updateNeeded === 'status' || updateNeeded === 'both') {
               this.elems.sticky.style.position = 'absolute';
-
               if ( this.attrParent === 'mobile' && this.isMobile ) {
                 this.elems.sticky.style.top = this.mainHeight - this.offset - this.height - this.attrOffsetBottom + 'px';
               } else {
@@ -186,39 +185,41 @@
     }
   };
 
-  var stickyNav = new StickyNav();
-
-  var loadDelay = stickyNav.elems.sticky.getAttribute('data-load-delay');
-  if (loadDelay) {
-    setTimeout(function() {
+  if (document.getElementsByClassName('sticky')[0].style.position === 'absolute') {
+    var stickyNav = new StickyNav();
+    var loadDelay = stickyNav.elems.sticky.getAttribute('data-load-delay');
+    if (loadDelay) {
+      setTimeout(function() {
+        stickyNav.run('init');
+      }, parseInt(loadDelay));
+    } else {
       stickyNav.run('init');
-    }, parseInt(loadDelay));
-  } else {
-    stickyNav.run('init');
+    }
+
+
+
+
+    window.addEventListener('scroll', stickyNav.throttle(stickyNav.run, 130, stickyNav));
+
+    window.addEventListener('resize', stickyNav.throttle(stickyNav.run, 150, stickyNav));
+
+    // documentation: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+    var observer = new MutationObserver(function () {
+      stickyNav.run();
+    });
+
+    // set up your configuration
+    // this will watch to see if you insert or remove any children
+    var config = { subtree: true, childList: true };
+
+    // start observing
+    observer.observe(stickyNav.elems.sticky, config);
+
+    // other potential elem listener
+    // http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/
+
+    exports.stickyNav = stickyNav;
   }
-
-
-
-  window.addEventListener('scroll', stickyNav.throttle(stickyNav.run, 130, stickyNav));
-
-  window.addEventListener('resize', stickyNav.throttle(stickyNav.run, 150, stickyNav));
-
-  // documentation: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
-  var observer = new MutationObserver(function () {
-    stickyNav.run();
-  });
-
-  // set up your configuration
-  // this will watch to see if you insert or remove any children
-  var config = { subtree: true, childList: true };
-
-  // start observing
-  observer.observe(stickyNav.elems.sticky, config);
-
-  // other potential elem listener
-  // http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/
-
-  exports.stickyNav = stickyNav;
 
 
 })(this);

--- a/js/lib/explore.min.js
+++ b/js/lib/explore.min.js
@@ -190,7 +190,6 @@
 	          if (this.diffBottom >= 0){
 	            if (updateNeeded === 'status' || updateNeeded === 'both') {
 	              this.elems.sticky.style.position = 'absolute';
-
 	              if ( this.attrParent === 'mobile' && this.isMobile ) {
 	                this.elems.sticky.style.top = this.mainHeight - this.offset - this.height - this.attrOffsetBottom + 'px';
 	              } else {
@@ -247,39 +246,41 @@
 	    }
 	  };
 
-	  var stickyNav = new StickyNav();
-
-	  var loadDelay = stickyNav.elems.sticky.getAttribute('data-load-delay');
-	  if (loadDelay) {
-	    setTimeout(function() {
+	  if (document.getElementsByClassName('sticky')[0].style.position === 'absolute') {
+	    var stickyNav = new StickyNav();
+	    var loadDelay = stickyNav.elems.sticky.getAttribute('data-load-delay');
+	    if (loadDelay) {
+	      setTimeout(function() {
+	        stickyNav.run('init');
+	      }, parseInt(loadDelay));
+	    } else {
 	      stickyNav.run('init');
-	    }, parseInt(loadDelay));
-	  } else {
-	    stickyNav.run('init');
+	    }
+
+
+
+
+	    window.addEventListener('scroll', stickyNav.throttle(stickyNav.run, 130, stickyNav));
+
+	    window.addEventListener('resize', stickyNav.throttle(stickyNav.run, 150, stickyNav));
+
+	    // documentation: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+	    var observer = new MutationObserver(function () {
+	      stickyNav.run();
+	    });
+
+	    // set up your configuration
+	    // this will watch to see if you insert or remove any children
+	    var config = { subtree: true, childList: true };
+
+	    // start observing
+	    observer.observe(stickyNav.elems.sticky, config);
+
+	    // other potential elem listener
+	    // http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/
+
+	    exports.stickyNav = stickyNav;
 	  }
-
-
-
-	  window.addEventListener('scroll', stickyNav.throttle(stickyNav.run, 130, stickyNav));
-
-	  window.addEventListener('resize', stickyNav.throttle(stickyNav.run, 150, stickyNav));
-
-	  // documentation: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
-	  var observer = new MutationObserver(function () {
-	    stickyNav.run();
-	  });
-
-	  // set up your configuration
-	  // this will watch to see if you insert or remove any children
-	  var config = { subtree: true, childList: true };
-
-	  // start observing
-	  observer.observe(stickyNav.elems.sticky, config);
-
-	  // other potential elem listener
-	  // http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/
-
-	  exports.stickyNav = stickyNav;
 
 
 	})(this);

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -23066,7 +23066,7 @@
 	module.exports = useNative() ? NativeCustomEvent :
 
 	// IE >= 9
-	'function' === typeof document.createEvent ? function CustomEvent (type, params) {
+	'undefined' !== typeof document && 'function' === typeof document.createEvent ? function CustomEvent (type, params) {
 	  var e = document.createEvent('CustomEvent');
 	  if (params) {
 	    e.initCustomEvent(type, params.bubbles, params.cancelable, params.detail);

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -195,7 +195,6 @@
 	          if (this.diffBottom >= 0){
 	            if (updateNeeded === 'status' || updateNeeded === 'both') {
 	              this.elems.sticky.style.position = 'absolute';
-
 	              if ( this.attrParent === 'mobile' && this.isMobile ) {
 	                this.elems.sticky.style.top = this.mainHeight - this.offset - this.height - this.attrOffsetBottom + 'px';
 	              } else {
@@ -252,39 +251,41 @@
 	    }
 	  };
 
-	  var stickyNav = new StickyNav();
-
-	  var loadDelay = stickyNav.elems.sticky.getAttribute('data-load-delay');
-	  if (loadDelay) {
-	    setTimeout(function() {
+	  if (document.getElementsByClassName('sticky')[0].style.position === 'absolute') {
+	    var stickyNav = new StickyNav();
+	    var loadDelay = stickyNav.elems.sticky.getAttribute('data-load-delay');
+	    if (loadDelay) {
+	      setTimeout(function() {
+	        stickyNav.run('init');
+	      }, parseInt(loadDelay));
+	    } else {
 	      stickyNav.run('init');
-	    }, parseInt(loadDelay));
-	  } else {
-	    stickyNav.run('init');
+	    }
+
+
+
+
+	    window.addEventListener('scroll', stickyNav.throttle(stickyNav.run, 130, stickyNav));
+
+	    window.addEventListener('resize', stickyNav.throttle(stickyNav.run, 150, stickyNav));
+
+	    // documentation: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+	    var observer = new MutationObserver(function () {
+	      stickyNav.run();
+	    });
+
+	    // set up your configuration
+	    // this will watch to see if you insert or remove any children
+	    var config = { subtree: true, childList: true };
+
+	    // start observing
+	    observer.observe(stickyNav.elems.sticky, config);
+
+	    // other potential elem listener
+	    // http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/
+
+	    exports.stickyNav = stickyNav;
 	  }
-
-
-
-	  window.addEventListener('scroll', stickyNav.throttle(stickyNav.run, 130, stickyNav));
-
-	  window.addEventListener('resize', stickyNav.throttle(stickyNav.run, 150, stickyNav));
-
-	  // documentation: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
-	  var observer = new MutationObserver(function () {
-	    stickyNav.run();
-	  });
-
-	  // set up your configuration
-	  // this will watch to see if you insert or remove any children
-	  var config = { subtree: true, childList: true };
-
-	  // start observing
-	  observer.observe(stickyNav.elems.sticky, config);
-
-	  // other potential elem listener
-	  // http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/
-
-	  exports.stickyNav = stickyNav;
 
 
 	})(this);


### PR DESCRIPTION
I only updated js/components/sticky-nav.js to fix the issue with the sidemenu, the .min.js files were updated because i ran `webpack`.