### PR TITLE
Multiple small changes for /explore/erdol-erdgas

### DIFF
--- a/_explore/erdol-erdgas.md
+++ b/_explore/erdol-erdgas.md
@@ -1,5 +1,5 @@
 ---
-title: Erdol, Erdgas
+title: Erdöl und Erdgas
 layout: default
 permalink: /explore/erdol-erdgas/
 breadcrumb:
@@ -40,7 +40,7 @@ nav_items:
   <section class="container" style="position: relative;">
 
     {% include breadcrumb.html %}
-    <h1 id="title">Erdöl, Erdgas</h1>
+    <h1 id="title">Erdöl un Erdgas</h1>
 
     <div class="container-left-9">
       <section id="erdol" style="position: relative;">
@@ -51,27 +51,27 @@ nav_items:
             <div>
               <p>
                 Deutschland deckt 2% seines Erdölbedarfs (rund 2,3 Millionen Barrel täglich) aus heimischer Produktion
-              </p>  
+              </p>
             </div>
             <div>
               <p>
                 Das im Wattenmeer gelegene Ölfeld Mittelplate/Dieksand beherbergt mit ca. 25 Mio. t rund 65 % der förderbaren deutschen Erdölvorkommen.
-              </p>  
+              </p>
             </div>
             <div>
               <p>
                 Erdöl und Erdgas entstehen aus Ablagerungen großer Mengen von Kleinstlebewesen vor allem Algen.
-              </p>  
+              </p>
             </div>
             <div>
               <p>
                 Die durchschnittlichen Kosten  eine heute typische Bohrung mit 5000 m Tiefe liegen bei ca. 10 Mio. € und steigen mit zunehmender Tiefe und in schwierig zugänglichen Lagerstätten noch deutlich an.
-              </p>  
+              </p>
             </div>
             <div>
               <p>
                 Seit Beginn der Erdöl- und Erdgasförderung in Deutschland wurden mehr als 22.000 Bohrungen durchgeführt
-              </p>  
+              </p>
             </div>
           </div>
         </section>
@@ -114,32 +114,32 @@ nav_items:
             <div>
               <p>
                 Erdgas wird im Vergleich zu Kohle und Erdöl erst seit relativ kurzer Zeit als Energieträger genutzt.
-              </p>  
+              </p>
             </div>
             <div>
               <p>
                 Erdgas wird im Vergleich zu Kohle und Erdöl erst seit relativ kurzer Zeit als Energieträger genutzt.
-              </p>  
+              </p>
             </div>
             <div>
               <p>
                 Auf einem ein Hektar großen Betriebsplatz wird Erdgas für die Versorgung von rund 15.000 Haushalten gefördert.
-              </p>  
+              </p>
             </div>
             <div>
               <p>
                 Bereits seit 60 Jahren wird Erdgas aus deutschen Lagerstätten gewonnen.
-              </p>  
+              </p>
             </div>
             <div>
               <p>
                 11% des Erdgasbedarfs in Deutschland wird durch die heimische Produktion gedeckt
-              </p>  
+              </p>
             </div>
             <div>
               <p>
                 95 % des geförderten Erdgases stammt aus Niedersachsen.
-              </p>  
+              </p>
             </div>
           </div>
         </section>

--- a/_explore/erdol-erdgas.md
+++ b/_explore/erdol-erdgas.md
@@ -95,14 +95,9 @@ nav_items:
         </section>
         <p>
           Erd&ouml;l ist ein fossiler Energietr&auml;ger und dient v.a. als
-          <a href="https://de.wikipedia.org/wiki/Kraftstoff">Treibstoff</a>
-          f&uuml;r
-          <a href="https://de.wikipedia.org/wiki/Verkehrsmittel">Verkehrs-</a>
-          und <a href="https://de.wikipedia.org/wiki/Transportmittel">Transportmittel</a>
-          und zur Beheizung von Geb&auml;uden. Zudem wird Erd&ouml;l in der
-          <a href="https://de.wikipedia.org/wiki/Erd%C3%B6l#Petrochemie">chemischen Industrie</a>
-          z.B. zur <a href="https://de.wikipedia.org/wiki/Produktion">Herstellung</a> von
-          <a href="https://de.wikipedia.org/wiki/Kunststoff">Kunststoffen</a> verwendet.
+          Treibstoff f&uuml;r Verkehrs-
+          und Transportmittel und zur Beheizung von Geb&auml;uden. Zudem wird Erd&ouml;l in der
+          chemischen Industrie z.B. zur Herstellung von Kunststoffen verwendet.
         </p>
       </section>
 

--- a/_explore/how-it-work/how-it-work.html
+++ b/_explore/how-it-work/how-it-work.html
@@ -23,7 +23,7 @@ permalink: /explore/how-it-work/
     </h2>
     <a href="{{ site.lang | url_lang_prefix  }}/explore/erdol-erdgas" class="tile tile-erdoel">
       <span>
-        Erdöl, Erdgas
+        Erdöl und Erdgas
       </span>
     </a>
     <a href="{{ site.lang | url_lang_prefix  }}/explore/kohle" class="tile tile-kohle">


### PR DESCRIPTION
- Change "Erdöl, Erdgas" to "Erdöl und Erdgas" (https://pfeffermind.atlassian.net/browse/GRM-89)

- On "Erdöl & Erdgas" Page remove the hyperlinks that lead to wikipedia. (https://pfeffermind.atlassian.net/browse/GRM-91)

- Check that the side mune correctly displays Ö and Ä etc. (https://pfeffermind.atlassian.net/browse/GRM-92)