### PR TITLE
fixed IE11 related issue with sidemenu (sidemenu overlapping top links)

### DIFF
--- a/_sass/components/_sticky.scss
+++ b/_sass/components/_sticky.scss
@@ -1,5 +1,4 @@
 .sticky {
-  background: $white;
   padding-top: $standard-padding-lite;
   position: -webkit-sticky;
   position: sticky;


### PR DESCRIPTION
fixed this issue:
![image uploaded from ios 1](https://cloud.githubusercontent.com/assets/11651398/22811614/440c78c6-ef16-11e6-82ca-80b067a0103e.jpg)
