### PR TITLE
added stickyfill-web-module to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "stream-array": "^1.0.1",
     "through2": "^0.6.5",
     "tito": "^0.3.0",
-    "yargs": "^3.7.1"
+    "yargs": "^3.7.1",
+    "stickyfill-web-module": "1.1.11"
   },
   "scripts": {
     "test": "mocha",


### PR DESCRIPTION
after installing "stickyfill-web-module" in production, the sidemenu should work fine. Apparently it's not installed now.